### PR TITLE
Add release workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+.gradle
+bin
+build
+gradle
+.dockerignore
+.gitignore
+Dockerfile
+gradlew*
+docker_run.sh
+README.md
+*.toml
+*.json

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,71 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '[0-9]+\\.[0-9]+\\.[0-9]+'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set version
+      id: version
+      run: |
+        VERSION=$(echo ${{ github.ref }} | sed -e "s#refs/tags/##g")
+        echo ::set-output name=version::${VERSION}
+
+    - uses: actions/checkout@v2
+
+    - name: Build
+      run: ./gradlew shadowJar
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ steps.version.outputs.version }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: false
+
+    - name: Upload Release Jar
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: build/libs/kelpie-lamb-all.jar
+        asset_name: kelpie-lamb-all.jar
+        asset_content_type: application/java-archive
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Cache Docker layers
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GHCR_PUSH }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        push: true
+        tags: |
+          ghcr.io/scalar-labs/kelpie-lamb:${{ steps.version.outputs.version }}
+          ghcr.io/scalar-labs/kelpie-lamb:latest
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - '[0-9]+\\.[0-9]+\\.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   release:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
-FROM openjdk:8u212-jre-slim-stretch
+FROM gradle:6.0.1-jdk8 AS build
+
+COPY . /kelpie-lamb
+WORKDIR /kelpie-lamb
+RUN gradle shadowJar
+
+FROM openjdk:8u275-jre-slim
 ENV KELPIE_VERSION 1.1.0
 
 RUN apt-get update && apt-get install wget unzip -y && \
@@ -10,7 +16,7 @@ RUN apt-get update && apt-get install wget unzip -y && \
 
 RUN mkdir -p /lamb/build/libs/
 
-COPY kelpie-lamb-all.jar /lamb/build/libs/
+COPY --from=build /kelpie-lamb/build/libs/kelpie-lamb-all.jar /lamb/build/libs/
 COPY sample-keys /lamb/sample-keys
 COPY entrypoint.sh /lamb/
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-![Lamb](https://github.com/scalar-labs/kelpie-test/workflows/Lamb/badge.svg)
+![Lamb](https://github.com/scalar-labs/kelpie-lamb/workflows/Lamb/badge.svg)
 
 # Kelpie Lamb
 Kelpie Lamb is a Kelpie extension for benchmarking of Scalar DL contracts.
 
-## Build
-
+## Build if needed
 ```console
 $ ./gradlew shadowJar
 ```
@@ -27,9 +26,14 @@ You can set up the environment with [scalar-terraform](https://github.com/scalar
     ```
 
 ### With docker
-#### Docker build
+#### Build if needed
 ```console
-$ ./gradlew docker
+$ docker build . -t ghcr.io/scalar-labs/kelpie-lamb
+```
+
+#### Pull from the GitHub Container Registry
+```console
+$ docker pull ghcr.io/scalar-labs/kelpie-lamb
 ```
 
 #### Run a test

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'java-library-distribution'
     id "com.github.johnrengelman.shadow" version "5.2.0"
-    id 'com.palantir.docker' version '0.25.0'
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -21,16 +21,5 @@ shadowJar {
     exclude 'sample_contract/*'
 }
 
-docker {
-    name 'ghcr.io/scalar-labs/kelpie-lamb'
-    files tasks.shadowJar.outputs, 'entrypoint.sh'
-    copySpec.with {
-        from('.') {
-            include 'sample-keys/**'
-            into '.'
-        }
-    }
-}
-
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -13,7 +13,6 @@ usage_exit() {
   exit 1
 }
 
-<<<<<<< HEAD
 get_absolute_path() {
   local file="${1}"
   local dir=$(cd $(dirname ${file}); pwd)
@@ -42,28 +41,6 @@ while [ $# -gt 0 ]; do
       ;;
     -t | --target-contract)
       target_contract=$(get_absolute_path "${2}")
-=======
-while [ $# -gt 0 ]; do
-  case ${1} in
-    -l | --lamb-config)
-      lamb_config="${2}"
-      shift 2
-      ;;
-    -c | --contract-config)
-      contract_config="${2}"
-      shift 2
-      ;;
-    -v | --variable-config)
-      variable_config="${2}"
-      shift 2
-      ;;
-    -p | --population-contract)
-      population_contract="${2}"
-      shift 2
-      ;;
-    -t | --target-contract)
-      target_contract="${2}"
->>>>>>> 750d3d9 (copy files and update docker_run.sh)
       shift 2
       ;;
     -e | --except-pre)

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -13,6 +13,7 @@ usage_exit() {
   exit 1
 }
 
+<<<<<<< HEAD
 get_absolute_path() {
   local file="${1}"
   local dir=$(cd $(dirname ${file}); pwd)
@@ -41,6 +42,28 @@ while [ $# -gt 0 ]; do
       ;;
     -t | --target-contract)
       target_contract=$(get_absolute_path "${2}")
+=======
+while [ $# -gt 0 ]; do
+  case ${1} in
+    -l | --lamb-config)
+      lamb_config="${2}"
+      shift 2
+      ;;
+    -c | --contract-config)
+      contract_config="${2}"
+      shift 2
+      ;;
+    -v | --variable-config)
+      variable_config="${2}"
+      shift 2
+      ;;
+    -p | --population-contract)
+      population_contract="${2}"
+      shift 2
+      ;;
+    -t | --target-contract)
+      target_contract="${2}"
+>>>>>>> 750d3d9 (copy files and update docker_run.sh)
       shift 2
       ;;
     -e | --except-pre)


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-7885

When a tag is pushed, jar and docker image are uploaded.
To build Docker image with the workflow plugin, I removed the docker configuration from `build.gradle`. So, `./gradlew docker` can't be used now.